### PR TITLE
Remove second URL for tzdata source which is not tzdata

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -7,8 +7,6 @@ package:
 source:
   - url: https://data.iana.org/time-zones/releases/tzdata{{ version }}.tar.gz
     sha256: 0d0434459acbd2059a7a8da1f3304a84a86591f6ed69c6248fffa502b6edffe3
-  - url: https://data.iana.org/time-zones/releases/tzcode{{ version }}.tar.gz
-    sha256: 80072894adff5a458f1d143e16e4ca1d8b2a122c9c5399da482cb68cba6a1ff8
 
 build:
   number: 0


### PR DESCRIPTION
Thankfully the second URL was only used in case of failure with the first one.